### PR TITLE
Fix potential flow stem for download links

### DIFF
--- a/_datarchives/potential_flow.md
+++ b/_datarchives/potential_flow.md
@@ -1,7 +1,7 @@
 ---
 layout: datarchive
 title: Potential Flow
-stem: potential flow
+stem: potential_flow
 has_image: true
 nbytes:
   - 62456340


### PR DESCRIPTION
Currently, on the [download page](https://visit-dav.github.io/largedata/datarchives/potential_flow) the links do not work for downloading - for example, it links to `https://github.com/visit-dav/largedata/blob/master/bindata/potential%20flow.zip?raw=true` instead of `https://github.com/visit-dav/largedata/raw/refs/heads/master/bindata/potential_flow.zip`. 
This fix to the stem should fix the download links.